### PR TITLE
Exclude non-data changes from affecting a feed's Last-Modified header

### DIFF
--- a/lib/upstream.js
+++ b/lib/upstream.js
@@ -31,11 +31,12 @@ async function getUpstreamRegistry(repoUrl) {
       'log', '--pretty=format:%h %at', '--', `src/main/schemas/${schemaFile}`
     ], { cwd: REPO_PATH, error: die })).stdout.split("\n")
 
-    // get HEAD in the same format as above:
+    // get HEAD of all data changes in the same format as above:
     const [ headLog ] = (await execFile('git', [
-      'log', '--pretty=format:%h %at', '--'
+      'log', '--pretty=format:%h %at', '--', DATA_PATH
     ], { cwd: REPO_PATH, error: die })).stdout.split("\n")
 
+    // checkout each historical version:
     const versionsDups = await [ headLog, ...oldSchemaLogs ].reduce(async (aProm, log, i) => {
       const a = await aProm
       const [ hash, commitUnixTime ] = log.split(' ') // see "%h %at"above


### PR DESCRIPTION
Changes to other parts of the code-base (in the upstream Registries repo) shouldn't affect the `Last-Modified` header in the JSON feed.